### PR TITLE
Update heatmap to default annotategames to true

### DIFF
--- a/client/commands/heatmap.js
+++ b/client/commands/heatmap.js
@@ -614,7 +614,7 @@ module.exports = {
     const eventId = interaction.options.getInteger('event') || event.id;
     const palleteIndex = interaction.options.getInteger('pallete') || 0;
     let offset = interaction.options.getInteger('offset');
-    let annotategames = interaction.options.getBoolean('annotategames') || false;
+    let annotategames = interaction.options.getBoolean('annotategames') ?? true;
     let bypoints = interaction.options.getBoolean('bypoints') || false;
 
     if (offset == null && offset != 0) offset = 18;


### PR DESCRIPTION
I almost always see people use heatmap with annotategames set to true; I think true should just be the default instead of false.

(Not tested because I don't have access to sekapi-js but I don't see why this wouldn't work)